### PR TITLE
Update wget path to fetch install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@
 #
 #   Must run as root:
 #  
-#    root@ubunu:~# wget https://raw.githubusercontent.com/opendevshop/devshop/1.0.0-rc3/install.sh
+#    root@ubunu:~# wget https://raw.githubusercontent.com/opendevshop/devshop/1.x/install.sh
 #    root@ubunu:~# bash install.sh --hostname=devshop.mydomain.com
 #
 #  Options:


### PR DESCRIPTION
Is currently set to an older branch that fails on essentially every version of Ubuntu (tested 17.04 and 14.04). Since it's a comment, it could be assumed anyone who reads this would be technical and fetching the latest version would be okay.